### PR TITLE
Fix "Prefer `format()` over string interpolation operator" issue

### DIFF
--- a/forms.py
+++ b/forms.py
@@ -62,10 +62,10 @@ class CronValidator(object):
 
             except:
                 raise ValidationError(
-                    '%s field has an error. Check current syntax and if values are within range %d-%d.' % (
+                    '{0!s} field has an error. Check current syntax and if values are within range {1:d}-{2:d}.'.format(
                         field.name.title(),
                         self._min,
-                        self._max,
+                        self._max
                 ))
 
 

--- a/views.py
+++ b/views.py
@@ -196,7 +196,7 @@ class NewJobAPI(MethodView):
             aps_job_fields = dict((field.name, str(field)) for field in aps_job.trigger.fields)
             jobs.insert({
                 'aps_job_id': aps_job.id,
-                'repr': '%(minute)s %(hour)s %(day_of_week)s %(week)s %(day)s %(month)s' % aps_job_fields,
+                'repr': '{minute!s} {hour!s} {day_of_week!s} {week!s} {day!s} {month!s}'.format(**aps_job_fields),
                 'user_id': user_id,
                 'repo_id': repo_id,
                 'created_datetime': datetime.now().strftime('%Y-%m-%d %H:%M:%S'),


### PR DESCRIPTION
This pull request automatically fixes all occurrences of the following issue:

Issue type: [Prefer `format()` over string interpolation operator](https://www.quantifiedcode.com/app/issue_class/4ACGxFj1)
Issue details: [https://www.quantifiedcode.com/app/project/gh:runt18:tron-ci?groups=code_patterns/%3A4ACGxFj1](https://www.quantifiedcode.com/app/project/gh:runt18:tron-ci?groups=code_patterns/%3A4ACGxFj1)

To adjust the commit message or the actual code changes, just [rebase](https://git-scm.com/docs/git-rebase) or [cherry-pick](https://git-scm.com/docs/git-cherry-pick) the commits.
For questions or feedback reach out to cody@quantifiedcode.com.

Legal note: We won't claim any copyrights on the code changes.

Cheers,
[Cody - Your code quality bot](https://www.quantifiedcode.com/cody)
